### PR TITLE
broken balloon but everything else works

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -368,7 +368,6 @@
 		/obj/item/flashlight/seclite,
 		/obj/item/food/donut,
 		/obj/item/grenade,
-		/obj/item/gun, //NOVA EDIT ADDITION
 		/obj/item/holosign_creator/security,
 		/obj/item/knife/combat,
 		/obj/item/melee/baton,

--- a/modular_nova/master_files/code/game/objects/items/storage/belt.dm
+++ b/modular_nova/master_files/code/game/objects/items/storage/belt.dm
@@ -1,0 +1,55 @@
+/obj/item/storage/belt/security
+	// new storage type with a thing to catch "do we have too many normal-sized items"
+	storage_type = /datum/storage/size_restricted
+
+/obj/item/storage/belt/security/Initialize(mapload)
+	. = ..()
+	atom_storage.max_slots = 5
+	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
+	atom_storage.set_holdable(list(
+		/obj/item/ammo_box,
+		/obj/item/ammo_casing/shotgun,
+		/obj/item/assembly/flash/handheld,
+		/obj/item/clothing/glasses,
+		/obj/item/clothing/gloves,
+		/obj/item/flashlight/seclite,
+		/obj/item/food/donut,
+		/obj/item/grenade,
+		/obj/item/gun,
+		/obj/item/holosign_creator/security,
+		/obj/item/knife/combat,
+		/obj/item/melee/baton,
+		/obj/item/radio,
+		/obj/item/reagent_containers/spray/pepper,
+		/obj/item/restraints/handcuffs,
+		/obj/item/restraints/legcuffs/bola,
+		))
+
+/datum/storage/size_restricted
+	/// w_class we're checking for
+	var/limited_size = WEIGHT_CLASS_NORMAL
+	/// how many normal items do we already have stored in this belt
+	var/limited_size_stored = 0
+	/// how mnay normal items do we want to keep, at maximum, in this belt (2, ideally, for a gun and baton, theoretically)
+	var/max_limited_size = 2
+
+/datum/storage/size_restricted/handle_enter(datum/source, obj/item/arrived)
+	. = ..()
+	count_normals()
+
+/datum/storage/size_restricted/handle_exit(datum/source, obj/item/gone)
+	. = ..()
+	count_normals()
+
+/datum/storage/size_restricted/can_insert(obj/item/to_insert, mob/user, messages, force)
+	if((to_insert.w_class >= limited_size) && (limited_size_stored >= max_limited_size))
+		if(messages && user)
+			user.balloon_alert(user, "no suitable space!")
+		return FALSE
+	. = ..()
+
+/datum/storage/size_restricted/proc/count_normals()
+	limited_size_stored = 0
+	for(var/obj/item/thing in real_location)
+		if(thing.w_class >= limited_size)
+			limited_size_stored++

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/saibasan/laser_guns.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/saibasan/laser_guns.dm
@@ -266,6 +266,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/cybersun_small_hellfire)
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_BELT
 	SET_BASE_PIXEL(0, 0)
+	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM
 	weapon_mode_options = list(
 		/datum/laser_weapon_mode/hellfire,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6324,6 +6324,7 @@
 #include "modular_nova\master_files\code\game\objects\items\devices\radio\radio.dm"
 #include "modular_nova\master_files\code\game\objects\items\stacks\sheets\sheet_types.dm"
 #include "modular_nova\master_files\code\game\objects\items\storage\backpack.dm"
+#include "modular_nova\master_files\code\game\objects\items\storage\belt.dm"
 #include "modular_nova\master_files\code\game\objects\items\storage\boxes.dm"
 #include "modular_nova\master_files\code\game\objects\items\storage\job_boxes.dm"
 #include "modular_nova\master_files\code\game\objects\items\tools\weldingtool.dm"


### PR DESCRIPTION
## About The Pull Request
- hoshi is normal size again
- secbelts can't hold more than 2 normal items

closes #1478

## How This Contributes To The Nova Sector Roleplay Experience

secbelts holding 5 guns is stupid but lowering the storage capability of a secbelt doesn't feel particularly right either

## Changelog

:cl:
balance: Cybersun Industries designed a better heatsink, allowing the Hoshi to fit in bags again.
balance: Security belts no longer hold more than 2 normal-size items. Storage capabilities largely remain the same, other than that.
/:cl: